### PR TITLE
Fix issue with player link

### DIFF
--- a/migrations/20211226_01_aVejE-create-base-tables.py
+++ b/migrations/20211226_01_aVejE-create-base-tables.py
@@ -81,7 +81,7 @@ steps = [
             'CREATE TABLE users('
             '    discord_id BIGSERIAL UNIQUE,\n'
             '    steam_id VARCHAR(18) UNIQUE,\n'
-            '    flag VARCHAR(3) DEFAULT NULL,\n'
+            '    flag VARCHAR DEFAULT NULL,\n'
             '    PRIMARY KEY (discord_id, steam_id)\n'
             ');'
         ),


### PR DESCRIPTION
When trying to link a player the bot returns `value too long for type character varying(3)` for the `flag` column. By removing the limit we can fix the issue and allow players to link.